### PR TITLE
Potential fix for code scanning alert no. 37: Reflected server-side cross-site scripting

### DIFF
--- a/server/src/user_interface/web_server/http_server.py
+++ b/server/src/user_interface/web_server/http_server.py
@@ -180,6 +180,12 @@ class HttpServer(BaseInterface):
 
                 content = pathlib.Path(full_path).read_bytes()
                 mimetype = guess_type(path)[0] or 'text/html'
+                # Only allow known-safe mimetypes
+                allowed_mimetypes = (
+                    'text/html', 'text/css', 'application/javascript', 'application/json', 'image/png', 'image/jpeg', 'image/gif', 'image/svg+xml', 'image/webp', 'font/woff', 'font/woff2', 'font/ttf', 'font/otf'
+                )
+                if mimetype not in allowed_mimetypes:
+                    mimetype = 'application/octet-stream'
                 Logger.trace(f"Serving {STATIC_PATH}/{path} ({len(content)} bytes) with mimetype {mimetype})")
                 return content, HTTP.OK, {'Content-Type': mimetype}
             except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/T0ine34/forge-server-manager/security/code-scanning/37](https://github.com/T0ine34/forge-server-manager/security/code-scanning/37)

To fix this XSS vulnerability, you should lock down which mime types can be served, rather than simply trusting the output of `guess_type()` on a user-controlled filename. The most effective and minimally disruptive approach is to whitelist permissible mimetypes (e.g., `text/css`, `application/javascript`, `image/*`, etc.) and default all else to `application/octet-stream` or another safe mime type. Additionally, you could sanitize or escape any case in which file or path info is reflected in the response body, but in this function that's not the case. Only edit the code in `static_proxy` within `server/src/user_interface/web_server/http_server.py` as shown. Insert a whitelist check just after the mimetype is chosen, and fallback to a safe type if an unapproved value is used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
